### PR TITLE
Add custom route for exporting dashboard embedded html

### DIFF
--- a/Angular2StarterKitWeb/app/_helpers/izendaintegrate.ts
+++ b/Angular2StarterKitWeb/app/_helpers/izendaintegrate.ts
@@ -113,6 +113,12 @@ export class IzendaIntegrate {
         IzendaSynergy.renderNewDashboardPage(document.getElementById('izenda-root'));
     }
 
+    RenderDashboardViewer()
+    {
+        this.setContext();
+        IzendaSynergy.izendaInitDashboardViewer(document.getElementById('izenda-root'), 'your dashboard viewer');
+    }
+
     DestroyDom(dom: any)
     {
          this.setContext();

--- a/Angular2StarterKitWeb/app/app.module.ts
+++ b/Angular2StarterKitWeb/app/app.module.ts
@@ -8,14 +8,14 @@ import { MockBackend, MockConnection } from "@angular/http/testing";
 import { BaseRequestOptions } from "@angular/http";
 
 import { AppComponent } from "./app.component";
-import { routing } from "./app.routing";
+import { Routing } from "./app.routing";
 
 import { AuthGuard } from "./_guards/index";
 import { AuthenticationService, UserService } from "./_services/index";
 import { LoginComponent } from "./login/index";
 import { RegisterComponent } from "./register/index";
 import { HomeComponent } from "./home/index";
-import { ExportReportComponent } from "./export/index";
+import { ExportReportComponent, ExportReportViewerComponent, ExportDashboardViewerComponent } from "./export/index";
 import { Navbar } from "./navbar/index";
 import {
   Dashboard,
@@ -26,7 +26,8 @@ import {
   ReportDesigner,
   ReportList,
   ReportPart,
-  ReportViewer
+  ReportViewer,
+  DashboardViewer
 } from "./izendacomponents/index";
 import { IzendaIntegrate } from "./_helpers/izendaintegrate";
 import { UrlSerializer } from "@angular/router";
@@ -36,13 +37,15 @@ import { CustomUrlSerializer } from "./_helpers/customurlserializer";
 //let IzendaBI =  './izenda/izenda_ui';
 
 @NgModule({
-  imports: [BrowserModule, FormsModule, HttpModule, routing],
+  imports: [BrowserModule, FormsModule, HttpModule, Routing],
   declarations: [
     AppComponent,
     LoginComponent,
     HomeComponent,
     RegisterComponent,
     ExportReportComponent,
+    ExportReportViewerComponent,
+    ExportDashboardViewerComponent,
     Dashboard,
     DashboardDesigner,
     IzendaHome,
@@ -52,6 +55,7 @@ import { CustomUrlSerializer } from "./_helpers/customurlserializer";
     ReportList,
     ReportPart,
     ReportViewer,
+    DashboardViewer,
     Navbar
   ],
   providers: [

--- a/Angular2StarterKitWeb/app/app.routing.ts
+++ b/Angular2StarterKitWeb/app/app.routing.ts
@@ -4,7 +4,7 @@ import { LoginComponent } from './login/index';
 import { RegisterComponent } from './register/index';
 import { HomeComponent } from './home/index';
 import { AuthGuard } from './_guards/index';
-import { ExportReportComponent, ExportReportViewerComponent } from './export/index';
+import { ExportReportComponent, ExportReportViewerComponent, ExportDashboardViewerComponent } from './export/index';
 import {Dashboard, DashboardDesigner, IzendaHome, IzendaSetting, ReportCustomFilter, ReportDesigner, ReportList, ReportPart, ReportViewer} from './izendacomponents/index'
 
 const appRoutes: Routes = [
@@ -23,9 +23,10 @@ const appRoutes: Routes = [
 
     // export route
      { path: 'viewer/reportpart/:id', component: ExportReportComponent},   
-     { path: 'report/view/:id', component: ExportReportViewerComponent}, 
+     { path: 'report/view/:id', component: ExportReportViewerComponent},   
+     { path: 'dashboard/view/:id', component: ExportDashboardViewerComponent}, 
     // otherwise redirect to home
     { path: '**', redirectTo: '' }
 ];
 
-export const routing = RouterModule.forRoot(appRoutes);
+export const Routing = RouterModule.forRoot(appRoutes);

--- a/Angular2StarterKitWeb/app/export/export.dashboardviewer.html
+++ b/Angular2StarterKitWeb/app/export/export.dashboardviewer.html
@@ -1,0 +1,1 @@
+<div id="izenda-export-dashboardviewer"></div>

--- a/Angular2StarterKitWeb/app/export/export.dashboardviewercomponent.ts
+++ b/Angular2StarterKitWeb/app/export/export.dashboardviewercomponent.ts
@@ -1,0 +1,37 @@
+import { Component, AfterViewInit } from '@angular/core';
+
+import { User } from '../_models/index';
+import { Router, ActivatedRoute, Params } from '@angular/router';
+let IzendaSynergy = require("../izenda/izenda_ui");
+
+@Component({
+    moduleId: module.id,
+    templateUrl: 'export.dashboardviewer.html'
+})
+
+export class ExportReportViewerComponent implements AfterViewInit {
+    currentUserContext: any = {};
+   repportId: string;
+    constructor( private router: Router, private activatedRoute: ActivatedRoute) { 
+    }
+
+    ngAfterViewInit() {
+        console.log(this.activatedRoute);
+        this.activatedRoute.params.subscribe((params: Params) => {
+            this.repportId = params['id'];
+        });
+
+        this.activatedRoute.queryParams.subscribe((params: Params) => {
+            let token = params['token'];
+            this.currentUserContext = { token: token};
+        });
+
+        console.log(this.repportId);
+        console.log(this.currentUserContext);
+        IzendaSynergy.setCurrentUserContext(this.currentUserContext); 
+        IzendaSynergy.renderReportViewerPage(document.getElementById('izenda-export-dashboardviewer'), {
+                "id": this.repportId,
+                "useQueryParam":true,
+            });
+    }
+}

--- a/Angular2StarterKitWeb/app/export/index.ts
+++ b/Angular2StarterKitWeb/app/export/index.ts
@@ -1,2 +1,3 @@
 export * from './export.component';
 export * from './export.reportviewercomponent';
+export * from './export.dashboardviewercomponent';

--- a/Angular2StarterKitWeb/app/izendacomponents/dashboardviewer.component.ts
+++ b/Angular2StarterKitWeb/app/izendacomponents/dashboardviewer.component.ts
@@ -1,0 +1,18 @@
+import { Component, AfterViewInit } from '@angular/core';
+// let IzendaSynergy = require("../izenda/izenda_ui");
+import {IzendaIntegrate} from '../_helpers/izendaintegrate';
+
+
+@Component({
+    moduleId: module.id,
+    templateUrl: 'rootcontainer.html'
+})
+
+export class DashboardViewer implements AfterViewInit {
+    constructor(private izItergrate: IzendaIntegrate) {
+     }
+
+    ngAfterViewInit() {
+        this.izItergrate.RenderDashboardViewer();
+    }
+}

--- a/Angular2StarterKitWeb/app/izendacomponents/index.ts
+++ b/Angular2StarterKitWeb/app/izendacomponents/index.ts
@@ -7,3 +7,4 @@ export * from './reportdesigner.component';
 export * from './reportlist.component';
 export * from './reportpart.component';
 export * from './reportviewer.component';
+export * from './dashboardviewer.component';


### PR DESCRIPTION
- Add custom route "dashboard/view/:id" to support Izenda back-end captures dashboard detail content in html format, using when end-user sent embedded dashboard email.
- Add dashboard viewer page

**Note: This feature is only available on Izenda 2.2.0 or newer**